### PR TITLE
Linux support

### DIFF
--- a/CefGlue.Avalonia/Platform/Linux/XWindow.cs
+++ b/CefGlue.Avalonia/Platform/Linux/XWindow.cs
@@ -53,9 +53,12 @@ namespace Xilium.CefGlue.Avalonia.Platform.Linux
 
         public void Dispose()
         {
-            EnsureDisplay();
-            XDestroyWindow(_display, Handle);
-            XFlush(_display);
+            if (_needDispose)
+            {
+                EnsureDisplay();
+                XDestroyWindow(_display, Handle);
+                XFlush(_display);
+            }
         }
     }
 }

--- a/CefGlue.Avalonia/Platform/Linux/XWindow.cs
+++ b/CefGlue.Avalonia/Platform/Linux/XWindow.cs
@@ -1,0 +1,61 @@
+﻿using Avalonia.Controls;
+using Avalonia.Platform;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Xilium.CefGlue.Avalonia.Platform.Linux
+{
+    internal class XWindow : IHandleHolder, IPlatformHandle
+    {
+        [DllImport("libX11.so.6")]
+        public static extern int XDestroyWindow(IntPtr display, IntPtr w);
+
+        [DllImport("libX11.so.6")]
+        public static extern IntPtr XOpenDisplay([MarshalAs(UnmanagedType.LPUTF8Str)] string display_name);
+
+        [DllImport("libX11.so.6")]
+        public static extern IntPtr XCreateSimpleWindow(IntPtr display, IntPtr parent, int x, int y, uint width, uint height, uint border_width, UIntPtr border, UIntPtr background);
+
+        [DllImport("libX11.so.6")]
+        public static extern IntPtr XDefaultRootWindow(IntPtr display);
+
+        [DllImport("libX11.so.6")]
+        public static extern int XFlush(IntPtr display);
+
+        public IntPtr Handle { get; private set; }
+
+        public string HandleDescriptor => "XWindow";
+
+        private static IntPtr _display;
+        private readonly bool _needDispose;
+
+        public XWindow(IntPtr handle, bool needDispose)
+        {
+            Handle = handle;
+            _needDispose = needDispose;
+        }
+
+        public static IPlatformHandle CreateHostWindow()
+        {
+            EnsureDisplay();
+            var handle = XCreateSimpleWindow(_display, XDefaultRootWindow(_display), 0, 0, 100, 100, 0, (UIntPtr)0, (UIntPtr)0);
+            XFlush(_display);
+            return new XWindow(handle, true);
+        }
+
+        private static void EnsureDisplay()
+        {
+            if (_display == IntPtr.Zero)
+            {
+                _display = XOpenDisplay(null);
+            }
+        }
+
+        public void Dispose()
+        {
+            EnsureDisplay();
+            XDestroyWindow(_display, Handle);
+            XFlush(_display);
+        }
+    }
+}

--- a/CefGlue.Common/CefRuntimeLoader.cs
+++ b/CefGlue.Common/CefRuntimeLoader.cs
@@ -5,13 +5,14 @@ using System.IO;
 using System.Reflection;
 using Xilium.CefGlue.Common.Handlers;
 using Xilium.CefGlue.Common.Shared;
+using System.Diagnostics;
 
 namespace Xilium.CefGlue.Common
 {
     public static class CefRuntimeLoader
     {
         private const string DefaultBrowserProcessDirectory = "CefGlueBrowserProcess";
-        
+
         private static Action<BrowserProcessHandler> _delayedInitialization;
 
         public static void Initialize(CefSettings settings = null, KeyValuePair<string, string>[] flags = null, CustomScheme[] customSchemes = null)
@@ -63,7 +64,15 @@ namespace Xilium.CefGlue.Common
             AppDomain.CurrentDomain.ProcessExit += delegate { CefRuntime.Shutdown(); };
 
             IsOSREnabled = settings.WindowlessRenderingEnabled;
-            CefRuntime.Initialize(new CefMainArgs(new string[0]), settings, new BrowserCefApp(customSchemes, flags, browserProcessHandler), IntPtr.Zero);
+
+            // On Linux, with osr disable, the filename in CefMainArgs will be use as accessible name.
+            // If the name is empty, chromium will crash at ui::AXNodeData:SetNamechecked.
+            var exeFileName = Process.GetCurrentProcess().MainModule.FileName;
+            if (string.IsNullOrEmpty(exeFileName))
+            {
+                exeFileName = "CefGlue";
+            }
+            CefRuntime.Initialize(new CefMainArgs(new[] { exeFileName }), settings, new BrowserCefApp(customSchemes, flags, browserProcessHandler), IntPtr.Zero);
 
             if (customSchemes != null)
             {
@@ -102,8 +111,10 @@ namespace Xilium.CefGlue.Common
 
         internal static bool IsOSREnabled { get; private set; }
 
-        private static string BrowserProcessFileName {
-            get {
+        private static string BrowserProcessFileName
+        {
+            get
+            {
                 const string Filename = "Xilium.CefGlue.BrowserProcess";
                 switch (CefRuntime.Platform)
                 {

--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -484,6 +484,12 @@ namespace Xilium.CefGlue.Common
             Control.DestroyRender();
             Cleanup(browser);
 
+            if (CefRuntime.Platform == CefRuntimePlatform.Linux)
+            {
+                // On Linux, we should return false to let cef close the browser window.
+                // We shouldn't close the window directly, or disposing browser will not work as expected.
+                return false;
+            }
             return true;
         }
 

--- a/CefGlue.Common/CommonBrowserAdapter.cs
+++ b/CefGlue.Common/CommonBrowserAdapter.cs
@@ -254,9 +254,11 @@ namespace Xilium.CefGlue.Common
         public void ShowDeveloperTools()
         {
             var windowInfo = CefWindowInfo.Create();
-            if (CefRuntime.Platform != CefRuntimePlatform.MacOS)
+
+            if (CefRuntime.Platform == CefRuntimePlatform.Windows)
             {
-                // don't know why but I can't do this on macosx
+                // This function set ParentHandle (owner in Windows) and set Bounds to CW_USERDEFAULT (only work in Windows).
+                // So, it should be called only in Windows.
                 windowInfo.SetAsPopup(BrowserHost?.GetWindowHandle() ?? IntPtr.Zero, "DevTools");
             }
 


### PR DESCRIPTION
X11 window embedding now works. Tested on Debian 12 x64 and [Kylin V10](https://en.wikipedia.org/wiki/Kylin_(operating_system)) (base on Debian 11) arm64.

But there's still some issues on arm64.
If we load libcef.so dynamic, it will fail with "cannot allocate memory in static TLS block". Maybe CLR uses too much TLS?
I tried `glibc.rtld.optional_static_tls` . It doesn't work. Maybe my linux os not support it. I don't know how to investigate it further.

Then I tried `LD_PRELOAD`, it works. But we need to do additional things to make it work with Avalonia. Cef uses `HarfBuzz`, and Avalonia also uses it. We must set `LD_PRELOAD=/path/to/libHarfBuzzSharp.so:/path/to/libcef.so` to ensure libHarfBuzzSharp load before cef, or the process will crash with SIGSEGV in HarfBuzz call.

We can also use [patchelf](https://github.com/NixOS/patchelf) to modify the elf file to load cef when process loading.
patchelf --add-needed libHarfBuzzSharp.so --add-needed libcef.so path/to/Xilium.CefGlue.Demo.Avalonia
patchelf --add-needed libcef.so path/to/Xilium.CefGlue.BrowserProcess (Browser process doesn't use Avalonia, so there's no need to add libHarfBuzzSharp.so)